### PR TITLE
Ntp validation

### DIFF
--- a/ESP_Woordklok/ESP_Woordklok.ino
+++ b/ESP_Woordklok/ESP_Woordklok.ino
@@ -143,7 +143,6 @@ void setup ( void ) {
 	server.begin();
 	//Serial.println( "HTTP server started" );
 	tkSecond.attach(1,Second_Tick);
-	UDPNTPClient.begin(2390);  // Port for NTP receive
 }
 
 
@@ -154,7 +153,6 @@ void handle_reboot() {
 
 void handle_update() {
     // Stop any trafficing
-    UDPNTPClient.stop();
     Serial.end();
     // Redirect to the real update
     server.sendHeader("Location","/update");

--- a/ESP_Woordklok/ESP_Woordklok.ino
+++ b/ESP_Woordklok/ESP_Woordklok.ino
@@ -198,8 +198,8 @@ void loop ( void ) {
 		else if ( cNTP_Update > (config.Update_Time_Via_NTP_Every * 60) )
 		{
 
+      cNTP_Update =0;
 			if ( NTPRefresh() ) {
-			cNTP_Update =0;
      UnixTimestamp_adjusted = UnixTimestamp + (config.timezone *  360);
       if (config.daylight) 
       UnixTimestamp_adjusted = UnixTimestamp_adjusted + adjustDstEurope();

--- a/ESP_Woordklok/ESP_Woordklok.ino
+++ b/ESP_Woordklok/ESP_Woordklok.ino
@@ -57,6 +57,7 @@ void setup ( void ) {
 	Serial.begin(9600);
   SPIFFS.begin();
 	delay(500);
+  WriteLogLine("ESP init: setting up clock.");
 	//Serial.println("Starting ES8266");
 	if (!ReadConfig())
 	{

--- a/ESP_Woordklok/ESP_Woordklok.ino
+++ b/ESP_Woordklok/ESP_Woordklok.ino
@@ -204,7 +204,7 @@ void loop ( void ) {
 
         if (config.Clock_NTP_Update) {
           Serial.println ("SET TIME " + FormatTime(hour()) + ":" + FormatTime(minute()) + ":" + FormatTime(second()) );
-          WriteLogLine ("SET TIME " + FormatTime(hour()) + ":" + FormatTime(minute()) + ":" + FormatTime(second()) );
+          WriteLogLine ("AUTO NTP SET TIME " + FormatTime(hour()) + ":" + FormatTime(minute()) + ":" + FormatTime(second()) );
         }
       } else {
         WriteLogLine("NTP FAILED UPDATE");        

--- a/ESP_Woordklok/ESP_Woordklok.ino
+++ b/ESP_Woordklok/ESP_Woordklok.ino
@@ -180,12 +180,7 @@ void loop ( void ) {
 		{
 			boolean refresh = NTPRefresh();
       if (!refresh) {
-        WriteLogLine("Failure to refresh NTP. Retrying once...");
-        NTPRefresh();
-      }
-      if (!refresh) {
         WriteLogLine("NTP failure. Clock might be out of time...");
-        NTPRefresh();
       }
 			cNTP_Update =0;
 			firstStart = false;

--- a/ESP_Woordklok/ESP_Woordklok.ino
+++ b/ESP_Woordklok/ESP_Woordklok.ino
@@ -216,15 +216,11 @@ void loop ( void ) {
 
 			cNTP_Update =0;
 			if ( NTPRefresh() ) {
-      int iHour = hour();
-      int iMinute = minute();
-      int iSecond = second();
       UnixTimestamp_adjusted = UnixTimestamp + (config.timezone *  360);
       if (config.daylight) 
       UnixTimestamp_adjusted = UnixTimestamp_adjusted + adjustDstEurope();
 
-      WriteLogLine("NTP TIME UPDATED using: " + UnixTimestamp); 
-      WriteLogLine ("CURRENT  " + FormatTime(iHour) + ":" + FormatTime(iMinute) + ":" + FormatTime(iSecond) );
+      WriteLogLine("NTP TIME UPDATED"); 
       setTime(UnixTimestamp_adjusted); //Convert to TimeLIB Library
       WriteLogLine ("SET TIME " + FormatTime(hour()) + ":" + FormatTime(minute()) + ":" + FormatTime(second()) );
       Serial.println ("SET TIME " + FormatTime(hour()) + ":" + FormatTime(minute()) + ":" + FormatTime(second()) );

--- a/ESP_Woordklok/Page_Admin.h
+++ b/ESP_Woordklok/Page_Admin.h
@@ -12,7 +12,7 @@ const char PAGE_AdminMainPage[] PROGMEM = R"=====(
 <a href="config.html" style="width:250px" class="btn btn--m btn--blue" >Network Configuration</a><br>
 <a href="info.html"   style="width:250px"  class="btn btn--m btn--blue" >Network Information</a><br>
 <a href="ntp.html"   style="width:250px"  class="btn btn--m btn--blue" >NTP Settings</a><br>
-<a href="Update.html"   style="width:250px"  class="btn btn--m btn--blue" >Update BIN File</a><br>
+<a href="update"   style="width:250px"  class="btn btn--m btn--blue" >Update BIN File</a><br>
 <a href="ResetLog.html"   style="width:250px"  class="btn btn--m btn--blue" >Reset Log File</a><br>
 
 <script>

--- a/ESP_Woordklok/Page_Admin.h
+++ b/ESP_Woordklok/Page_Admin.h
@@ -12,7 +12,7 @@ const char PAGE_AdminMainPage[] PROGMEM = R"=====(
 <a href="config.html" style="width:250px" class="btn btn--m btn--blue" >Network Configuration</a><br>
 <a href="info.html"   style="width:250px"  class="btn btn--m btn--blue" >Network Information</a><br>
 <a href="ntp.html"   style="width:250px"  class="btn btn--m btn--blue" >NTP Settings</a><br>
-<a href="update"   style="width:250px"  class="btn btn--m btn--blue" >Update BIN File</a><br>
+<a href="Update.html"   style="width:250px"  class="btn btn--m btn--blue" >Update BIN File</a><br>
 <a href="ResetLog.html"   style="width:250px"  class="btn btn--m btn--blue" >Reset Log File</a><br>
 
 <script>

--- a/ESP_Woordklok/global.h
+++ b/ESP_Woordklok/global.h
@@ -250,11 +250,8 @@ boolean NTPRefresh()
 	{
 		IPAddress timeServerIP; 
 		WiFi.hostByName(config.ntpServerName.c_str(), timeServerIP); 
-		//sendNTPpacket(timeServerIP); // send an NTP packet to a time server
 
-
-		//Serial.println("sending NTP packet...");
-    WriteLogLine("Sending NTP packet... ");
+    // WriteLogLine("Sending NTP packet... ");
 		memset(packetBuffer, 0, NTP_PACKET_SIZE);
 		packetBuffer[0] = 0b11100011;   // LI, Version, Mode
 		packetBuffer[1] = 0;     // Stratum, or type of clock
@@ -268,19 +265,15 @@ boolean NTPRefresh()
 		UDPNTPClient.write(packetBuffer, NTP_PACKET_SIZE);
 		UDPNTPClient.endPacket();
 
-
 		delay(1000);
   
 		int cb = UDPNTPClient.parsePacket();
 		if (!cb) {
-			//Serial.println("NTP no packet yet");
-		//  WriteLogLine("NTP no packet yet");
+		  //  WriteLogLine("NTP no packet yet");
 		}
 		else 
 		{
-			//Serial.print("NTP packet received, length=");
-			//Serial.println(cb);
-			WriteLogLine("NTP packet received; length: " + (String) cb);
+			// WriteLogLine("NTP packet received; length: " + (String) cb);
 			UDPNTPClient.read(packetBuffer, NTP_PACKET_SIZE); // read the packet into the buffer
 			unsigned long highWord = word(packetBuffer[40], packetBuffer[41]);
 			unsigned long lowWord = word(packetBuffer[42], packetBuffer[43]);
@@ -289,7 +282,7 @@ boolean NTPRefresh()
 			unsigned long epoch = secsSince1900 - seventyYears;
 			UnixTimestamp = epoch;
       FirstPackage = true;
-			WriteLogLine("NTP packet time is: " + (String) epoch);
+			// WriteLogLine("NTP packet time is: " + (String) epoch);
       UDPNTPClient.flush();
       UDPNTPClient.stop();
       return true;

--- a/ESP_Woordklok/global.h
+++ b/ESP_Woordklok/global.h
@@ -233,7 +233,7 @@ void ReadClockConfig()
 
 const int NTP_PACKET_SIZE = 48; 
 byte packetBuffer[ NTP_PACKET_SIZE]; 
-void NTPRefresh()
+boolean NTPRefresh()
 {
 
 	
@@ -282,8 +282,10 @@ void NTPRefresh()
 			unsigned long epoch = secsSince1900 - seventyYears;
 			UnixTimestamp = epoch;
       FirstPackage = true;
+      return true;
 		}
 	}
+ return false;
 }
 
 void Second_Tick()

--- a/ESP_Woordklok/global.h
+++ b/ESP_Woordklok/global.h
@@ -60,6 +60,12 @@ struct strConfig {
 }   config;
 
 
+void WriteLogLine(String LogLine){
+    File bestand = SPIFFS.open("/data.txt", "a+"); // open het bestand in schrijf modus.
+    bestand.println(String(hour()) + ":" + String(minute()) + ":" + String(second()) + " - " + LogLine);
+    bestand.close();
+}
+
 /*
 **
 ** CONFIGURATION HANDLING
@@ -247,7 +253,7 @@ boolean NTPRefresh()
 
 
 		//Serial.println("sending NTP packet...");
-//    WriteLogLine("sending NTP packet...");
+    WriteLogLine("Sending NTP packet... ");
 		memset(packetBuffer, 0, NTP_PACKET_SIZE);
 		packetBuffer[0] = 0b11100011;   // LI, Version, Mode
 		packetBuffer[1] = 0;     // Stratum, or type of clock
@@ -273,7 +279,7 @@ boolean NTPRefresh()
 		{
 			//Serial.print("NTP packet received, length=");
 			//Serial.println(cb);
-	//		WriteLogLine("NTP packet received, length=" + (String) cb);
+			WriteLogLine("NTP packet received; length: " + (String) cb);
 			UDPNTPClient.read(packetBuffer, NTP_PACKET_SIZE); // read the packet into the buffer
 			unsigned long highWord = word(packetBuffer[40], packetBuffer[41]);
 			unsigned long lowWord = word(packetBuffer[42], packetBuffer[43]);
@@ -282,6 +288,9 @@ boolean NTPRefresh()
 			unsigned long epoch = secsSince1900 - seventyYears;
 			UnixTimestamp = epoch;
       FirstPackage = true;
+			WriteLogLine("NTP packet time is: " + (String) epoch);
+      UDPNTPClient.flush();
+
       return true;
 		}
 	}
@@ -312,11 +321,6 @@ void Second_Tick()
 	Refresh = true;
 }
 
-void WriteLogLine(String LogLine){
-    File bestand = SPIFFS.open("/data.txt", "a+"); // open het bestand in schrijf modus.
-    bestand.println(String(hour()) + ":" + String(minute()) + ":" + String(second()) + " - " + LogLine);
-    bestand.close();
-}
 
 void ResetLogFile (){
     File bestand = SPIFFS.open("/data.txt", "w"); // open het bestand in schrijf modus.

--- a/ESP_Woordklok/global.h
+++ b/ESP_Woordklok/global.h
@@ -241,6 +241,7 @@ const int NTP_PACKET_SIZE = 48;
 byte packetBuffer[ NTP_PACKET_SIZE]; 
 boolean NTPRefresh()
 {
+  UDPNTPClient.begin(2390);  // Port for NTP receive
 
 	
 
@@ -290,10 +291,11 @@ boolean NTPRefresh()
       FirstPackage = true;
 			WriteLogLine("NTP packet time is: " + (String) epoch);
       UDPNTPClient.flush();
-
+      UDPNTPClient.stop();
       return true;
 		}
 	}
+ UDPNTPClient.stop();
  return false;
 }
 


### PR DESCRIPTION
- Set UTF-8 charset for logfile.
- Check if the NTP update succeeds; do not update time if it fails.
- Open and close NTP connection each time to prevent reuse of old buffer.
- Writelogline moved to be able to use it in NTPRefresh.

Still to fix: When there is no internet connection, clock will be set at 1 o'clock (DST offset).
